### PR TITLE
fix: 인덱스 레인지 스캔이 아닌 풀스캔이 일어나서 COALESCE 삭제 후 OR 문을 사용하게 변경

### DIFF
--- a/src/main/java/kr/co/fastcampus/fastcatch/domain/accommodation/repository/AccommodationRepository.java
+++ b/src/main/java/kr/co/fastcampus/fastcatch/domain/accommodation/repository/AccommodationRepository.java
@@ -12,8 +12,8 @@ import org.springframework.data.repository.query.Param;
 public interface AccommodationRepository extends JpaRepository<Accommodation, Long> {
 
     @Query("SELECT a FROM Accommodation a WHERE "
-        + "a.region = COALESCE(:region, a.region) "
-        + "AND a.category = COALESCE(:category, a.category) "
+        + "(a.region = :region OR :region IS NULL) "
+        + "AND (a.category = :category OR :category IS NULL) "
         + "AND a.maximumCapacity >= :headCount")
     Page<Accommodation> findAccommodations(
         @Param("region") Region region,


### PR DESCRIPTION
## 개요
인덱스 레인지 스캔이 아닌 풀스캔이 일어나서 COALESCE 삭제 후 OR 문을 사용하게 변경
COALESCE 함수 사용하지 않고 OR 조건을 사용해서 인덱스 스캔이 가능하게끔 수정 

## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)